### PR TITLE
/track pass

### DIFF
--- a/lib/slash_command/track.ex
+++ b/lib/slash_command/track.ex
@@ -12,6 +12,7 @@ defmodule Blurber.ApplicationCommands.Track do
   alias PS2.API.Query
 
   @none_voicepack_dirs ["README.md", "TEMPLATE"]
+  @max_retries 4
 
   @impl Nosedrum.ApplicationCommand
   def description do
@@ -53,7 +54,7 @@ defmodule Blurber.ApplicationCommands.Track do
   end
 
   @impl Nosedrum.ApplicationCommand
-  def command(%Interaction{guild_id: guild_id, channel_id: channel_id} = interaction) do
+  def command(%Interaction{guild_id: guild_id} = interaction) do
     with options <- Blurber.get_options(interaction),
          {:ok, character_name} <- Map.fetch(options, "character_name"),
          {:ok, voicepack} <- Map.fetch(options, "voicepack"),
@@ -62,7 +63,7 @@ defmodule Blurber.ApplicationCommands.Track do
       # Run the rest of the command in another process and defer the full response with Discord.
       # The Census query can take more than 5 seconds to run (and even randomly fail...)
       Task.start(fn ->
-        do_command(interaction, guild_id, channel_id, character_name, voicepack, vc_id)
+        do_command(interaction, character_name, voicepack, vc_id)
       end)
 
       [type: :deferred_channel_message_with_source]
@@ -75,6 +76,7 @@ defmodule Blurber.ApplicationCommands.Track do
         [content: "Please join a voice channel."]
 
       {:error, guild_fetch_reason} ->
+        # when guild_fetch_reason in [:id_not_found, :id_not_found_on_guild_lookup] ->
         Logger.error("Could not get guild from guild_id: #{inspect(guild_fetch_reason)}")
 
         [
@@ -84,48 +86,57 @@ defmodule Blurber.ApplicationCommands.Track do
     end
   end
 
-  def do_command(interaction, guild_id, channel_id, character_name, voicepack, vc_id) do
+  defp do_command(interaction, character_name, voicepack, vc_id, remaining_tries \\ @max_retries)
+
+  defp do_command(interaction, character_name, _voicepack, _vc_id, 0) do
     content =
-      Query.new(collection: "character")
-      |> term("name.first_lower", String.downcase(character_name))
-      |> limit(1)
-      |> show("character_id")
-      |> PS2.API.query_one(Blurber.service_id())
-      |> case do
-        {:ok, %QueryResult{data: %{"character_id" => character_id}}} ->
-          PS2.Socket.subscribe!(Blurber.Socket, Blurber.ESS.subscription(character_id))
+      "Could not get #{character_name}'s ID, please double check the spelling and try again."
 
-          with {:error, :not_found} <- Blurber.ESS.session_pid(character_id),
-               :ok <- Blurber.ESS.new_session(character_id, voicepack, guild_id, channel_id),
-               :ok <- Nostrum.Voice.join_channel(guild_id, vc_id) do
-            """
-            Successfully joined voice channel.
-            Listening to events from #{character_name} (ID #{character_id}), using voicepack '#{voicepack}'
-            """
-          else
-            {:ok, pid} when is_pid(pid) ->
-              """
-              It looks like someone else in this server is currently tracking a character - you must wait for them to
-              logout or for their tracking session to expire (#{Session.afk_timeout_ms() / (60 * 1000)} minutes of no
-              events) before starting a new tracking session in this server.
-              """
+    Nostrum.Api.edit_interaction_response(interaction, %{content: content})
+  end
 
-            e ->
-              Logger.error(
-                "Could not create a new session and join the voice channel: #{inspect(e)}"
-              )
+  defp do_command(interaction, character_name, voicepack, vc_id, remaining_tries) do
+    %Interaction{guild_id: guild_id, channel_id: channel_id} = interaction
 
-              "Could not join the voice channel, please try again soon."
-          end
+    content =
+      with {:ok, %QueryResult{data: %{"character_id" => character_id}}} <- query(character_name),
+           :ok <- PS2.Socket.subscribe!(Blurber.Socket, Blurber.ESS.subscription(character_id)),
+           {:error, :not_found} <- Blurber.ESS.session_pid(character_id),
+           :ok <- Blurber.ESS.new_session(character_id, voicepack, guild_id, channel_id),
+           :ok <- Nostrum.Voice.join_channel(guild_id, vc_id) do
+        """
+        Successfully joined voice channel.
+        Listening to events from #{character_name} (ID #{character_id}), using voicepack '#{voicepack}'
+        """
+      else
+        {:ok, pid} when is_pid(pid) ->
+          """
+          It looks like someone else in this server is currently tracking a character - you must wait for them to
+          logout or for their tracking session to expire (#{Session.afk_timeout_ms() / (60 * 1000)} minutes of no
+          events) before starting a new tracking session in this server.
+          """
 
         {:ok, %QueryResult{}} ->
-          "Could not get that character's ID, please double check the spelling and try again."
+          "Could not get #{character_name}'s ID, please double check the spelling and try again."
 
         {:error, error} ->
           Logger.error("Could not fetch character_id in /track: #{inspect(error)}")
-          "Could not get that character's ID, please double check the spelling and try again."
+          do_command(interaction, character_name, voicepack, vc_id, remaining_tries - 1)
+
+        e ->
+          Logger.error("Could not create a new session and join the voice channel: #{inspect(e)}")
+
+          "Could not join the voice channel, please try again soon."
       end
 
     Nostrum.Api.edit_interaction_response(interaction, %{content: content})
+  end
+
+  defp query(character_name) do
+    Query.new(collection: "character")
+    |> term("name.first_lower", String.downcase(character_name))
+    |> limit(1)
+    |> show("character_id")
+    |> PS2.API.query_one(Blurber.service_id())
   end
 end


### PR DESCRIPTION
- refactor
- attempted to fix seemingly random timeout/lack of response (possibly due to the `edit_interaction_response` reaching discord before the initial defer?)
- Census query is now retried up to 4 times